### PR TITLE
Add Redis client abstraction and DI registration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# .NET build outputs
+bin/
+obj/
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/CryptoNet.Common/CryptoNet.Common.csproj
+++ b/CryptoNet.Common/CryptoNet.Common.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="StackExchange.Redis" Version="2.6.122" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="6.0.0" />
+  </ItemGroup>
+</Project>

--- a/CryptoNet.Common/IRedisClient.cs
+++ b/CryptoNet.Common/IRedisClient.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Threading.Tasks;
+
+namespace CryptoNet.Common;
+
+/// <summary>
+/// Abstraction over a Redis client that exposes a small set of common operations
+/// used throughout the application. The abstraction keeps the dependency on the
+/// StackExchange.Redis library isolated and simplifies testing by allowing the
+/// implementation to be mocked.
+/// </summary>
+public interface IRedisClient
+{
+    /// <summary>
+    /// Retrieve the value stored for <paramref name="key" /> and deserialize it into <typeparamref name="T" />.
+    /// </summary>
+    /// <typeparam name="T">Type that the stored value will be deserialized into.</typeparam>
+    /// <param name="key">Redis key.</param>
+    /// <returns>The stored value or <c>null</c> when the key does not exist.</returns>
+    Task<T?> GetAsync<T>(string key);
+
+    /// <summary>
+    /// Store <paramref name="value" /> at <paramref name="key" /> optionally setting a key expiration.
+    /// </summary>
+    /// <typeparam name="T">Type of value to persist.</typeparam>
+    /// <param name="key">Redis key.</param>
+    /// <param name="value">
+    /// Value to persist. The value will be serialized to JSON when it is not a string or byte array.
+    /// </param>
+    /// <param name="expiry">Optional expiration for the key.</param>
+    Task SetAsync<T>(string key, T value, TimeSpan? expiry = null);
+
+    /// <summary>
+    /// Delete the value stored for <paramref name="key" />.
+    /// </summary>
+    /// <param name="key">Redis key.</param>
+    /// <returns><c>true</c> when a key was removed.</returns>
+    Task<bool> DeleteAsync(string key);
+
+    /// <summary>
+    /// Check whether the provided key exists in Redis.
+    /// </summary>
+    /// <param name="key">Redis key.</param>
+    /// <returns><c>true</c> when the key exists.</returns>
+    Task<bool> ExistsAsync(string key);
+}

--- a/CryptoNet.Common/RedisClient.cs
+++ b/CryptoNet.Common/RedisClient.cs
@@ -1,0 +1,118 @@
+using System;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Options;
+using StackExchange.Redis;
+
+namespace CryptoNet.Common;
+
+/// <inheritdoc cref="IRedisClient" />
+public class RedisClient : IRedisClient
+{
+    private readonly IDatabase _database;
+    private readonly JsonSerializerOptions _serializerOptions;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RedisClient"/> class.
+    /// </summary>
+    /// <param name="connectionMultiplexer">The shared Redis connection.</param>
+    /// <param name="options">Options that control how values are serialized and which database is targeted.</param>
+    public RedisClient(IConnectionMultiplexer connectionMultiplexer, IOptions<RedisOptions> options)
+    {
+        if (connectionMultiplexer is null)
+        {
+            throw new ArgumentNullException(nameof(connectionMultiplexer));
+        }
+
+        if (options is null)
+        {
+            throw new ArgumentNullException(nameof(options));
+        }
+
+        var redisOptions = options.Value ?? throw new ArgumentException("Options value cannot be null.", nameof(options));
+        _database = connectionMultiplexer.GetDatabase(redisOptions.DefaultDatabase ?? -1);
+        _serializerOptions = new JsonSerializerOptions(JsonSerializerDefaults.Web);
+    }
+
+    /// <inheritdoc />
+    public async Task<T?> GetAsync<T>(string key)
+    {
+        EnsureKey(key);
+
+        var redisValue = await _database.StringGetAsync(key).ConfigureAwait(false);
+        if (redisValue.IsNullOrEmpty)
+        {
+            return default;
+        }
+
+        if (typeof(T) == typeof(string))
+        {
+            return (T)(object)redisValue.ToString();
+        }
+
+        if (typeof(T) == typeof(byte[]))
+        {
+            return (T)(object)((byte[])redisValue);
+        }
+
+        if (typeof(T) == typeof(RedisValue))
+        {
+            return (T)(object)redisValue;
+        }
+
+        try
+        {
+            var json = redisValue.ToString();
+            return JsonSerializer.Deserialize<T>(json, _serializerOptions);
+        }
+        catch (JsonException exception)
+        {
+            throw new InvalidOperationException(
+                $"Unable to deserialize the value stored at key '{key}' to type '{typeof(T)}'.",
+                exception);
+        }
+    }
+
+    /// <inheritdoc />
+    public Task SetAsync<T>(string key, T value, TimeSpan? expiry = null)
+    {
+        EnsureKey(key);
+
+        if (value is null)
+        {
+            throw new ArgumentNullException(nameof(value));
+        }
+
+        RedisValue redisValue = value switch
+        {
+            RedisValue rv => rv,
+            string stringValue => stringValue,
+            byte[] bytes => bytes,
+            _ => JsonSerializer.Serialize(value, _serializerOptions)
+        };
+
+        return _database.StringSetAsync(key, redisValue, expiry);
+    }
+
+    /// <inheritdoc />
+    public Task<bool> DeleteAsync(string key)
+    {
+        EnsureKey(key);
+        return _database.KeyDeleteAsync(key);
+    }
+
+    /// <inheritdoc />
+    public Task<bool> ExistsAsync(string key)
+    {
+        EnsureKey(key);
+        return _database.KeyExistsAsync(key);
+    }
+
+    private static void EnsureKey(string key)
+    {
+        if (string.IsNullOrWhiteSpace(key))
+        {
+            throw new ArgumentException("Redis key cannot be null or whitespace.", nameof(key));
+        }
+    }
+}

--- a/CryptoNet.Common/RedisOptions.cs
+++ b/CryptoNet.Common/RedisOptions.cs
@@ -1,0 +1,48 @@
+namespace CryptoNet.Common;
+
+/// <summary>
+/// Options used to configure the Redis connection and default behaviour for <see cref="RedisClient"/>.
+/// </summary>
+public class RedisOptions
+{
+    /// <summary>
+    /// Connection string that will be used when provided. When not specified the <see cref="Host"/> and <see cref="Port"/>
+    /// values will be used to build a <see cref="StackExchange.Redis.ConfigurationOptions"/> instance.
+    /// </summary>
+    public string? ConnectionString { get; set; }
+
+    /// <summary>
+    /// Host of the Redis server. Defaults to <c>localhost</c>.
+    /// </summary>
+    public string Host { get; set; } = "localhost";
+
+    /// <summary>
+    /// Port of the Redis server. Defaults to the standard Redis port 6379.
+    /// </summary>
+    public int Port { get; set; } = 6379;
+
+    /// <summary>
+    /// Password required to authenticate against the Redis server.
+    /// </summary>
+    public string? Password { get; set; }
+
+    /// <summary>
+    /// Default database to use. When <c>null</c> the connection default will be used.
+    /// </summary>
+    public int? DefaultDatabase { get; set; }
+
+    /// <summary>
+    /// Optional logical client name.
+    /// </summary>
+    public string? ClientName { get; set; }
+
+    /// <summary>
+    /// Whether SSL should be used for the connection.
+    /// </summary>
+    public bool Ssl { get; set; }
+
+    /// <summary>
+    /// Controls the value of <see cref="StackExchange.Redis.ConfigurationOptions.AbortOnConnectFail"/>.
+    /// </summary>
+    public bool AbortOnConnectFail { get; set; } = true;
+}

--- a/CryptoNet.Common/RedisServiceCollectionExtensions.cs
+++ b/CryptoNet.Common/RedisServiceCollectionExtensions.cs
@@ -1,0 +1,114 @@
+using System;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
+using StackExchange.Redis;
+
+namespace CryptoNet.Common;
+
+/// <summary>
+/// Extension methods that register the Redis infrastructure with a dependency injection container.
+/// </summary>
+public static class RedisServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers the Redis client infrastructure using values provided through configuration binding.
+    /// </summary>
+    /// <param name="services">The service collection to configure.</param>
+    /// <param name="configuration">Configuration section that contains the <see cref="RedisOptions"/> values.</param>
+    /// <returns>The same service collection instance for chaining.</returns>
+    public static IServiceCollection AddRedisClient(this IServiceCollection services, IConfiguration configuration)
+    {
+        if (services is null)
+        {
+            throw new ArgumentNullException(nameof(services));
+        }
+
+        if (configuration is null)
+        {
+            throw new ArgumentNullException(nameof(configuration));
+        }
+
+        services.Configure<RedisOptions>(configuration);
+        RegisterRedisServices(services);
+        return services;
+    }
+
+    /// <summary>
+    /// Registers the Redis client infrastructure using programmatic configuration.
+    /// </summary>
+    /// <param name="services">The service collection to configure.</param>
+    /// <param name="configureOptions">Delegate used to configure <see cref="RedisOptions"/>.</param>
+    /// <returns>The same service collection instance for chaining.</returns>
+    public static IServiceCollection AddRedisClient(this IServiceCollection services, Action<RedisOptions> configureOptions)
+    {
+        if (services is null)
+        {
+            throw new ArgumentNullException(nameof(services));
+        }
+
+        if (configureOptions is null)
+        {
+            throw new ArgumentNullException(nameof(configureOptions));
+        }
+
+        services.Configure(configureOptions);
+        RegisterRedisServices(services);
+        return services;
+    }
+
+    private static void RegisterRedisServices(IServiceCollection services)
+    {
+        services.TryAddSingleton<IConnectionMultiplexer>(provider =>
+        {
+            var options = provider.GetRequiredService<IOptions<RedisOptions>>().Value;
+            return CreateConnectionMultiplexer(options);
+        });
+
+        services.TryAddSingleton<IRedisClient, RedisClient>();
+    }
+
+    private static IConnectionMultiplexer CreateConnectionMultiplexer(RedisOptions options)
+    {
+        if (options is null)
+        {
+            throw new ArgumentNullException(nameof(options));
+        }
+
+        if (!string.IsNullOrWhiteSpace(options.ConnectionString))
+        {
+            return ConnectionMultiplexer.Connect(options.ConnectionString);
+        }
+
+        if (string.IsNullOrWhiteSpace(options.Host))
+        {
+            throw new InvalidOperationException("A Redis host or connection string must be provided.");
+        }
+
+        var configurationOptions = new ConfigurationOptions
+        {
+            AbortOnConnectFail = options.AbortOnConnectFail,
+            Ssl = options.Ssl,
+        };
+
+        configurationOptions.EndPoints.Add(options.Host, options.Port);
+
+        if (!string.IsNullOrWhiteSpace(options.Password))
+        {
+            configurationOptions.Password = options.Password;
+        }
+
+        if (!string.IsNullOrWhiteSpace(options.ClientName))
+        {
+            configurationOptions.ClientName = options.ClientName;
+        }
+
+        if (options.DefaultDatabase.HasValue)
+        {
+            configurationOptions.DefaultDatabase = options.DefaultDatabase.Value;
+        }
+
+        return ConnectionMultiplexer.Connect(configurationOptions);
+    }
+}


### PR DESCRIPTION
## Summary
- add a new CryptoNet.Common class library with redis options, interface, and implementation
- expose extension methods to register the redis client and connection multiplexer with DI
- ignore .NET build output directories in version control

## Testing
- dotnet build CryptoNet.Common/CryptoNet.Common.csproj *(fails: `dotnet` CLI not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ca7447e7d083239ee0e9c61961ce34