### PR TITLE
Add CryptoNet.TradeLiquidationCapturer project

### DIFF
--- a/CryptoNet.TradeLiquidationCapturer/Abstractions/IBinanceTradeLiquidationClient.cs
+++ b/CryptoNet.TradeLiquidationCapturer/Abstractions/IBinanceTradeLiquidationClient.cs
@@ -1,0 +1,5 @@
+namespace CryptoNet.TradeLiquidationCapturer.Abstractions;
+
+public interface IBinanceTradeLiquidationClient : ITradeLiquidationStreamClient
+{
+}

--- a/CryptoNet.TradeLiquidationCapturer/Abstractions/IHyperliquidTradeLiquidationClient.cs
+++ b/CryptoNet.TradeLiquidationCapturer/Abstractions/IHyperliquidTradeLiquidationClient.cs
@@ -1,0 +1,5 @@
+namespace CryptoNet.TradeLiquidationCapturer.Abstractions;
+
+public interface IHyperliquidTradeLiquidationClient : ITradeLiquidationStreamClient
+{
+}

--- a/CryptoNet.TradeLiquidationCapturer/Abstractions/ITradeLiquidationStreamClient.cs
+++ b/CryptoNet.TradeLiquidationCapturer/Abstractions/ITradeLiquidationStreamClient.cs
@@ -1,0 +1,13 @@
+using System.Runtime.CompilerServices;
+using CryptoNet.TradeLiquidationCapturer.Models;
+
+namespace CryptoNet.TradeLiquidationCapturer.Abstractions;
+
+public interface ITradeLiquidationStreamClient : IAsyncDisposable
+{
+    string Exchange { get; }
+
+    Task ConnectAsync(CancellationToken cancellationToken = default);
+
+    IAsyncEnumerable<TradeLiquidationEvent> StreamLiquidationsAsync([EnumeratorCancellation] CancellationToken cancellationToken = default);
+}

--- a/CryptoNet.TradeLiquidationCapturer/Binance/BinanceTradeLiquidationClient.cs
+++ b/CryptoNet.TradeLiquidationCapturer/Binance/BinanceTradeLiquidationClient.cs
@@ -1,0 +1,32 @@
+using CryptoNet.TradeLiquidationCapturer.Abstractions;
+using CryptoNet.TradeLiquidationCapturer.Options;
+using CryptoNet.TradeLiquidationCapturer.WebSockets;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace CryptoNet.TradeLiquidationCapturer.Binance;
+
+internal sealed class BinanceTradeLiquidationClient : WebSocketTradeLiquidationClient, IBinanceTradeLiquidationClient
+{
+    public BinanceTradeLiquidationClient(IOptions<TradeLiquidationCapturerOptions> options, ILogger<BinanceTradeLiquidationClient> logger)
+        : base(
+            ResolveEndpoint(options, out var resolvedOptions),
+            logger,
+            resolvedOptions.ReceiveBufferSize,
+            resolvedOptions.KeepAliveInterval,
+            Normalize(resolvedOptions.BinanceSubscriptionMessage))
+    {
+    }
+
+    public override string Exchange => "Binance";
+
+    private static Uri ResolveEndpoint(IOptions<TradeLiquidationCapturerOptions>? options, out TradeLiquidationCapturerOptions resolved)
+    {
+        resolved = options?.Value ?? new TradeLiquidationCapturerOptions();
+        resolved.EnsureValid();
+        return resolved.BinanceEndpoint;
+    }
+
+    private static string? Normalize(string? message)
+        => string.IsNullOrWhiteSpace(message) ? null : message;
+}

--- a/CryptoNet.TradeLiquidationCapturer/CryptoNet.TradeLiquidationCapturer.csproj
+++ b/CryptoNet.TradeLiquidationCapturer/CryptoNet.TradeLiquidationCapturer.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.0" />
+  </ItemGroup>
+
+</Project>

--- a/CryptoNet.TradeLiquidationCapturer/Extensions/ServiceCollectionExtensions.cs
+++ b/CryptoNet.TradeLiquidationCapturer/Extensions/ServiceCollectionExtensions.cs
@@ -1,0 +1,30 @@
+using CryptoNet.TradeLiquidationCapturer.Abstractions;
+using CryptoNet.TradeLiquidationCapturer.Binance;
+using CryptoNet.TradeLiquidationCapturer.Hyperliquid;
+using CryptoNet.TradeLiquidationCapturer.Options;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace CryptoNet.TradeLiquidationCapturer.Extensions;
+
+public static class ServiceCollectionExtensions
+{
+    public static IServiceCollection AddTradeLiquidationCapturer(this IServiceCollection services, Action<TradeLiquidationCapturerOptions>? configure = null)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        var builder = services.AddOptions<TradeLiquidationCapturerOptions>();
+        builder.PostConfigure(options => options.EnsureValid());
+
+        if (configure is not null)
+        {
+            builder.Configure(configure);
+        }
+
+        services.AddSingleton<IBinanceTradeLiquidationClient, BinanceTradeLiquidationClient>();
+        services.AddSingleton<IHyperliquidTradeLiquidationClient, HyperliquidTradeLiquidationClient>();
+        services.AddSingleton<ITradeLiquidationStreamClient>(sp => sp.GetRequiredService<IBinanceTradeLiquidationClient>());
+        services.AddSingleton<ITradeLiquidationStreamClient>(sp => sp.GetRequiredService<IHyperliquidTradeLiquidationClient>());
+
+        return services;
+    }
+}

--- a/CryptoNet.TradeLiquidationCapturer/Hyperliquid/HyperliquidTradeLiquidationClient.cs
+++ b/CryptoNet.TradeLiquidationCapturer/Hyperliquid/HyperliquidTradeLiquidationClient.cs
@@ -1,0 +1,32 @@
+using CryptoNet.TradeLiquidationCapturer.Abstractions;
+using CryptoNet.TradeLiquidationCapturer.Options;
+using CryptoNet.TradeLiquidationCapturer.WebSockets;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace CryptoNet.TradeLiquidationCapturer.Hyperliquid;
+
+internal sealed class HyperliquidTradeLiquidationClient : WebSocketTradeLiquidationClient, IHyperliquidTradeLiquidationClient
+{
+    public HyperliquidTradeLiquidationClient(IOptions<TradeLiquidationCapturerOptions> options, ILogger<HyperliquidTradeLiquidationClient> logger)
+        : base(
+            ResolveEndpoint(options, out var resolvedOptions),
+            logger,
+            resolvedOptions.ReceiveBufferSize,
+            resolvedOptions.KeepAliveInterval,
+            Normalize(resolvedOptions.HyperliquidSubscriptionMessage))
+    {
+    }
+
+    public override string Exchange => "Hyperliquid";
+
+    private static Uri ResolveEndpoint(IOptions<TradeLiquidationCapturerOptions>? options, out TradeLiquidationCapturerOptions resolved)
+    {
+        resolved = options?.Value ?? new TradeLiquidationCapturerOptions();
+        resolved.EnsureValid();
+        return resolved.HyperliquidEndpoint;
+    }
+
+    private static string? Normalize(string? message)
+        => string.IsNullOrWhiteSpace(message) ? null : message;
+}

--- a/CryptoNet.TradeLiquidationCapturer/Models/TradeLiquidationEvent.cs
+++ b/CryptoNet.TradeLiquidationCapturer/Models/TradeLiquidationEvent.cs
@@ -1,0 +1,9 @@
+namespace CryptoNet.TradeLiquidationCapturer.Models;
+
+/// <summary>
+/// Represents a raw liquidation message emitted by an exchange WebSocket stream.
+/// </summary>
+/// <param name="Exchange">The exchange that emitted the message.</param>
+/// <param name="RawMessage">The raw JSON payload received from the WebSocket stream.</param>
+/// <param name="ReceivedAt">The timestamp (in UTC) when the message was received by the client.</param>
+public sealed record TradeLiquidationEvent(string Exchange, string RawMessage, DateTimeOffset ReceivedAt);

--- a/CryptoNet.TradeLiquidationCapturer/Options/TradeLiquidationCapturerOptions.cs
+++ b/CryptoNet.TradeLiquidationCapturer/Options/TradeLiquidationCapturerOptions.cs
@@ -1,0 +1,80 @@
+namespace CryptoNet.TradeLiquidationCapturer.Options;
+
+/// <summary>
+/// Provides configuration values for the trade liquidation WebSocket clients.
+/// </summary>
+public sealed class TradeLiquidationCapturerOptions
+{
+    private static readonly Uri DefaultBinanceEndpoint = new("wss://fstream.binance.com/stream?streams=!forceOrder@arr");
+    private static readonly Uri DefaultHyperliquidEndpoint = new("wss://api.hyperliquid.xyz/ws");
+
+    /// <summary>
+    /// Gets or sets the WebSocket endpoint for Binance liquidation streams.
+    /// </summary>
+    public Uri BinanceEndpoint { get; set; } = DefaultBinanceEndpoint;
+
+    /// <summary>
+    /// Gets or sets an optional subscription message sent immediately after the Binance connection is established.
+    /// </summary>
+    public string? BinanceSubscriptionMessage { get; set; }
+
+    /// <summary>
+    /// Gets or sets the WebSocket endpoint for Hyperliquid liquidation streams.
+    /// </summary>
+    public Uri HyperliquidEndpoint { get; set; } = DefaultHyperliquidEndpoint;
+
+    /// <summary>
+    /// Gets or sets an optional subscription message sent immediately after the Hyperliquid connection is established.
+    /// </summary>
+    public string? HyperliquidSubscriptionMessage { get; set; }
+
+    /// <summary>
+    /// Gets or sets the keep-alive interval applied to the WebSocket connections.
+    /// </summary>
+    public TimeSpan KeepAliveInterval { get; set; } = TimeSpan.FromSeconds(15);
+
+    /// <summary>
+    /// Gets or sets the size, in bytes, of the receive buffer used for incoming WebSocket messages.
+    /// </summary>
+    public int ReceiveBufferSize { get; set; } = 8192;
+
+    internal void EnsureValid()
+    {
+        BinanceEndpoint ??= DefaultBinanceEndpoint;
+        HyperliquidEndpoint ??= DefaultHyperliquidEndpoint;
+
+        if (ReceiveBufferSize <= 0)
+        {
+            throw new InvalidOperationException("ReceiveBufferSize must be greater than zero.");
+        }
+
+        if (KeepAliveInterval < TimeSpan.Zero)
+        {
+            throw new InvalidOperationException("KeepAliveInterval must not be negative.");
+        }
+
+        if (!BinanceEndpoint.IsAbsoluteUri)
+        {
+            throw new InvalidOperationException("BinanceEndpoint must be an absolute URI.");
+        }
+
+        if (!HyperliquidEndpoint.IsAbsoluteUri)
+        {
+            throw new InvalidOperationException("HyperliquidEndpoint must be an absolute URI.");
+        }
+
+        if (!IsWebSocketScheme(BinanceEndpoint))
+        {
+            throw new InvalidOperationException("BinanceEndpoint must use the ws or wss scheme.");
+        }
+
+        if (!IsWebSocketScheme(HyperliquidEndpoint))
+        {
+            throw new InvalidOperationException("HyperliquidEndpoint must use the ws or wss scheme.");
+        }
+    }
+
+    private static bool IsWebSocketScheme(Uri uri)
+        => string.Equals(uri.Scheme, "ws", StringComparison.OrdinalIgnoreCase)
+           || string.Equals(uri.Scheme, "wss", StringComparison.OrdinalIgnoreCase);
+}

--- a/CryptoNet.TradeLiquidationCapturer/WebSockets/WebSocketTradeLiquidationClient.cs
+++ b/CryptoNet.TradeLiquidationCapturer/WebSockets/WebSocketTradeLiquidationClient.cs
@@ -1,0 +1,219 @@
+using System.Buffers;
+using System.Net.WebSockets;
+using System.Text;
+using CryptoNet.TradeLiquidationCapturer.Abstractions;
+using CryptoNet.TradeLiquidationCapturer.Models;
+using Microsoft.Extensions.Logging;
+
+namespace CryptoNet.TradeLiquidationCapturer.WebSockets;
+
+internal abstract class WebSocketTradeLiquidationClient : ITradeLiquidationStreamClient
+{
+    private readonly SemaphoreSlim _connectionLock = new(1, 1);
+    private readonly Uri _endpoint;
+    private readonly ILogger _logger;
+    private readonly int _receiveBufferSize;
+    private readonly TimeSpan _keepAliveInterval;
+    private readonly string? _subscriptionMessage;
+    private ClientWebSocket? _client;
+    private bool _disposed;
+    private int _isStreaming;
+
+    protected WebSocketTradeLiquidationClient(
+        Uri endpoint,
+        ILogger logger,
+        int receiveBufferSize,
+        TimeSpan keepAliveInterval,
+        string? subscriptionMessage = null)
+    {
+        _endpoint = endpoint ?? throw new ArgumentNullException(nameof(endpoint));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+
+        if (receiveBufferSize <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(receiveBufferSize), receiveBufferSize, "The receive buffer size must be greater than zero.");
+        }
+
+        if (keepAliveInterval < TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(nameof(keepAliveInterval), keepAliveInterval, "The keep-alive interval cannot be negative.");
+        }
+
+        _receiveBufferSize = receiveBufferSize;
+        _keepAliveInterval = keepAliveInterval;
+        _subscriptionMessage = string.IsNullOrWhiteSpace(subscriptionMessage) ? null : subscriptionMessage;
+    }
+
+    public abstract string Exchange { get; }
+
+    public async Task ConnectAsync(CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+
+        await _connectionLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            ThrowIfDisposed();
+
+            if (_client?.State == WebSocketState.Open)
+            {
+                return;
+            }
+
+            _client?.Dispose();
+            _client = new ClientWebSocket();
+            _client.Options.KeepAliveInterval = _keepAliveInterval;
+            ConfigureClientWebSocketOptions(_client.Options);
+
+            _logger.LogInformation("Connecting to {Exchange} liquidation stream at {Endpoint}", Exchange, _endpoint);
+            await _client.ConnectAsync(_endpoint, cancellationToken).ConfigureAwait(false);
+            await OnConnectedAsync(_client, cancellationToken).ConfigureAwait(false);
+
+            if (_subscriptionMessage is { } message)
+            {
+                var payload = Encoding.UTF8.GetBytes(message);
+                await _client.SendAsync(new ArraySegment<byte>(payload), WebSocketMessageType.Text, true, cancellationToken).ConfigureAwait(false);
+                _logger.LogDebug("Sent subscription message to {Exchange}: {Message}", Exchange, message);
+            }
+        }
+        finally
+        {
+            _connectionLock.Release();
+        }
+    }
+
+    protected virtual void ConfigureClientWebSocketOptions(ClientWebSocketOptions options)
+    {
+        options.SetRequestHeader("User-Agent", "CryptoNet.TradeLiquidationCapturer");
+    }
+
+    protected virtual ValueTask OnConnectedAsync(ClientWebSocket socket, CancellationToken cancellationToken) => ValueTask.CompletedTask;
+
+    public async IAsyncEnumerable<TradeLiquidationEvent> StreamLiquidationsAsync([System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+
+        if (Interlocked.CompareExchange(ref _isStreaming, 1, 0) != 0)
+        {
+            throw new InvalidOperationException("The WebSocket client is already streaming.");
+        }
+
+        try
+        {
+            await ConnectAsync(cancellationToken).ConfigureAwait(false);
+            var socket = _client ?? throw new InvalidOperationException("The WebSocket client is not connected.");
+
+            var buffer = new byte[_receiveBufferSize];
+            var writer = new ArrayBufferWriter<byte>(_receiveBufferSize);
+
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                WebSocketReceiveResult result;
+                try
+                {
+                    result = await socket.ReceiveAsync(new ArraySegment<byte>(buffer), cancellationToken).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException)
+                {
+                    yield break;
+                }
+
+                if (result.MessageType == WebSocketMessageType.Close)
+                {
+                    _logger.LogWarning("{Exchange} closed the WebSocket connection with status {Status} ({Description}).", Exchange, result.CloseStatus, result.CloseStatusDescription);
+
+                    try
+                    {
+                        await socket.CloseAsync(WebSocketCloseStatus.NormalClosure, "Closing as requested by server.", cancellationToken).ConfigureAwait(false);
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogDebug(ex, "Error while acknowledging close frame from {Exchange}.", Exchange);
+                    }
+
+                    yield break;
+                }
+
+                if (result.MessageType != WebSocketMessageType.Text)
+                {
+                    _logger.LogDebug("Ignoring non-text WebSocket message from {Exchange}. MessageType: {MessageType}", Exchange, result.MessageType);
+                    continue;
+                }
+
+                if (result.Count > 0)
+                {
+                    writer.Write(buffer.AsSpan(0, result.Count));
+                }
+
+                if (!result.EndOfMessage)
+                {
+                    continue;
+                }
+
+                var rawMessage = Encoding.UTF8.GetString(writer.WrittenSpan);
+                writer.Clear();
+
+                if (string.IsNullOrWhiteSpace(rawMessage))
+                {
+                    continue;
+                }
+
+                var @event = CreateEvent(rawMessage);
+                if (@event is not null)
+                {
+                    yield return @event;
+                }
+            }
+        }
+        finally
+        {
+            Interlocked.Exchange(ref _isStreaming, 0);
+        }
+    }
+
+    protected virtual TradeLiquidationEvent? CreateEvent(string rawMessage)
+        => new TradeLiquidationEvent(Exchange, rawMessage, DateTimeOffset.UtcNow);
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+
+        _connectionLock.Dispose();
+
+        if (_client is null)
+        {
+            return;
+        }
+
+        try
+        {
+            if (_client.State is WebSocketState.Open or WebSocketState.CloseReceived)
+            {
+                await _client.CloseAsync(WebSocketCloseStatus.NormalClosure, "Disposing client", CancellationToken.None).ConfigureAwait(false);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Failed to close WebSocket connection for {Exchange} gracefully.", Exchange);
+        }
+        finally
+        {
+            _client.Dispose();
+            _client = null;
+        }
+    }
+
+    protected void ThrowIfDisposed()
+    {
+        if (_disposed)
+        {
+            throw new ObjectDisposedException(GetType().Name);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- create the `CryptoNet.TradeLiquidationCapturer` .NET 8 class library
- add reusable abstractions, options, and base WebSocket infrastructure for liquidation streams
- implement Binance and Hyperliquid WebSocket clients and register them for dependency injection

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68ca742293c883238c79b2b8f0e12119